### PR TITLE
updated how-to.md

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -48,6 +48,12 @@ or
 npm server
 ```
 
+If you do not have electron installed run
+```
+npm install -g electron
+```
+and then try the above step again.
+
 ### Where to Put the Code
 
 All the relevant code is  in [`ui_src/ui`](https://github.com/sarahgp/la-habra/tree/master/ui_src/ui). In particular, `core.cljs` is the only file you will need at performance time. It imports all the necessary dependencies.


### PR DESCRIPTION
added a comment for installing electron package globally in order to get la habra to run on first install